### PR TITLE
Add Magic to binary file check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ dill==0.3.8
 litellm==1.41.7
 tiktoken
 pyinstaller==6.8.0
+python-magic


### PR DESCRIPTION
This PR is an attempt to make the binary exclusion a little safer, and avoid trying to upload potentially large binary files.  it maintains the binary file extension check, but augments it with an additional Magic-based check for MIME type.  MIME types that start with "application/", "image/", "audio/", and "video/" are treated as binary, with the exception of "application/xhtml+xml" and "application/xml" files which are treated as non-binary.

The downside of this patch is that it adds an OS-level requirement - magic - which may not be installed by all users.  