### PR TITLE
Fix normalization of file name for filtering

### DIFF
--- a/lib/embedding_util.py
+++ b/lib/embedding_util.py
@@ -48,7 +48,7 @@ def get_top_relevant_files(startpath, upload_filter, query, model_embedding, num
     for root, _, file_list in os.walk(startpath):
         for file in file_list:
             file_path = os.path.join(root, file)
-            if (upload_filter.should_upload(file)):
+            if (upload_filter.should_upload(os.path.relpath(os.path.join(root, file), startpath))):
                 try:
                     with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                         content = f.read()

--- a/lib/file_util.py
+++ b/lib/file_util.py
@@ -189,7 +189,7 @@ def get_files(startpath, upload_filter):
         files = [
             f
             for f in files
-            if upload_filter.should_upload(os.path.relpath(os.path.join(root, f)))
+            if upload_filter.should_upload(os.path.relpath(os.path.join(root, f), startpath))
         ]
         for f in files:
             file_path = os.path.relpath(os.path.join(root, f), startpath)


### PR DESCRIPTION
The file name is coming out with a leading `./` without this in the focused case, and so file lookup is failing.

Added the startpath to both cases for consistency.
