### PR TITLE
Add package-log.json to default excluded files.

### DIFF
--- a/lib/uploaded_file_filter.py
+++ b/lib/uploaded_file_filter.py
@@ -29,6 +29,7 @@ DEFAULT_IGNORE_PATTERNS = [
     "**/.arcode.embeddings",
     "**/.DS_Store",
     "**/.env",
+    "**/package-lock.json"
 ]
 
 class UploadedFileFilter:


### PR DESCRIPTION
I can't really see a case where uploading this file is helpful, and it's large (but not ridiculously large) on normal apps.  It also chunks extraordinarily poorly.  So I suggest adding it to the default.